### PR TITLE
feat: compute voicings from state

### DIFF
--- a/src/ui/ProgressionInput.test.tsx
+++ b/src/ui/ProgressionInput.test.tsx
@@ -1,0 +1,39 @@
+import './test-setup'
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import ProgressionInput from './ProgressionInput'
+import VoicingCarousel from './VoicingCarousel'
+import { useStore } from '../state/store'
+import { test, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+
+beforeEach(() => {
+  useStore.setState({
+    key: 'C',
+    mode: 'major',
+    tuning: ['E', 'A', 'D', 'G', 'B', 'E'],
+    progression: '',
+    voicings: [],
+    selectedVoicingIdx: 0,
+  })
+})
+
+test('changing progression recomputes voicings and rerenders', () => {
+  render(
+    <>
+      <ProgressionInput />
+      <VoicingCarousel />
+    </>,
+  )
+  const input = screen.getByLabelText('progression')
+  fireEvent.change(input, { target: { value: 'I' } })
+  let fretboard = screen.getByTestId('fretboard')
+  let tablature = screen.getByTestId('tablature')
+  assert.equal(fretboard.getAttribute('data-frets'), '-1,3,2,0,1,0')
+  assert.equal(tablature.getAttribute('data-frets'), '-1,3,2,0,1,0')
+  fireEvent.change(input, { target: { value: 'V' } })
+  fretboard = screen.getByTestId('fretboard')
+  tablature = screen.getByTestId('tablature')
+  assert.equal(fretboard.getAttribute('data-frets'), '3,2,0,0,0,3')
+  assert.equal(tablature.getAttribute('data-frets'), '3,2,0,0,0,3')
+})


### PR DESCRIPTION
## Summary
- compute guitar chord voicings in the Zustand store
- recompute voicings when key/mode/tuning/progression change
- test progression input triggers voicing recomputation and rerendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689904745f708332a57fdd9af051557a