### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -1,0 +1,56 @@
+name: Build & Publish to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Build (with GH Pages base path)
+        env:
+          # Set base to "/<repo>/" so assets work at the subdirectory
+          BASE_PATH: "/${{ github.event.repository.name }}/"
+        run: |
+          npm run build
+          # SPA fallback for deep links
+          cp dist/index.html dist/404.html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # bookish-barnacle
 Make Guitar Playing Better
+
+## GitHub Pages
+This project publishes to GitHub Pages using Actions. To enable Pages:
+
+1. Go to your repository on GitHub.
+2. Navigate to **Settings** → **Pages**.
+3. Under "Build and deployment", set **Source** to "GitHub Actions".
+


### PR DESCRIPTION
## Summary
- add GitHub Pages workflow using Node 20 and npm cache
- document enabling Pages in repo settings

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899081f929c8332aa9f1bbe44f8c3f3